### PR TITLE
projects/awg: document AD9144 TPL timed-control insertion boundaries

### DIFF
--- a/projects/awg/SYSTEM_OVERVIEW.md
+++ b/projects/awg/SYSTEM_OVERVIEW.md
@@ -164,3 +164,81 @@ main()
 
 4. **Atomic clock path** — define the external PLL needed to derive 122.88 MHz
    from a 5/10 MHz atomic reference. See [clock_architecture.md](./clock_architecture.md).
+
+## 9. TPL timed-control insertion map (AD9144 AWG path)
+
+This section maps where FTW/POW/ASF-equivalent DDS controls currently enter the
+`axi_ad9144_tpl/dac_tpl_core` path, and records concrete insertion boundaries.
+
+### 9.1 Exposed vs internal-only TPL control interfaces
+
+- **AXI-visible control interface (from block design):**
+  - `axi_ad9144_tpl/s_axi_aclk`
+  - `axi_ad9144_tpl/s_axi_aresetn`
+  - `axi_ad9144_tpl/s_axi` (mapped at `0x44A04000`)
+- **Data/stream interfaces exported by TPL hierarchy:**
+  - `axi_ad9144_tpl/link_clk`
+  - `axi_ad9144_tpl/link`
+  - `axi_ad9144_tpl/dac_dunf`
+  - `axi_ad9144_tpl/dac_enable_<i>`, `axi_ad9144_tpl/dac_valid_<i>`, `axi_ad9144_tpl/dac_data_<i>`
+- **Control-relevant pins that are currently internal-only (not exported by the hierarchy):**
+  - `axi_ad9144_tpl/dac_tpl_core/dac_sync_in`
+  - `axi_ad9144_tpl/dac_tpl_core/dac_sync_manual_req_in`
+  - `axi_ad9144_tpl/dac_tpl_core/dac_sync_manual_req_out`
+
+### 9.2 Where DDS control words are latched (per converter/tone)
+
+`dac_tpl_core` is `library/jesd204/ad_ip_jesd204_tpl_dac/ad_ip_jesd204_tpl_dac.v`.
+Its register map and channel control path are:
+
+1. **AXI write decode and per-channel register capture (`up_clk` domain):**
+   - `ad_ip_jesd204_tpl_dac_regmap` instantiates one `up_dac_channel` per converter.
+   - In `up_dac_channel`, writes latch:
+     - tone0 scale/init/incr into `up_dac_dds_scale_1`, `up_dac_dds_init_1`, `up_dac_dds_incr_1`
+     - tone1 scale/init/incr into `up_dac_dds_scale_2`, `up_dac_dds_init_2`, `up_dac_dds_incr_2`
+     - high-word extensions (for `DDS_PHASE_DW > 16`) into
+       `up_dac_dds_init_1_hi`, `up_dac_dds_incr_1_hi`, `up_dac_dds_init_2_hi`, `up_dac_dds_incr_2_hi`
+2. **Commit across clock domains (`up_clk` -> `dac_clk/link_clk`):**
+   - `up_xfer_cntrl` transfers packed control bus into
+     `dac_dds_scale_1/2`, `dac_dds_init_1/2`, `dac_dds_incr_1/2`.
+3. **Per-channel DDS use in TPL datapath (`link_clk` domain):**
+   - `ad_ip_jesd204_tpl_dac_core` slices arrays per converter and drives
+     `ad_ip_jesd204_tpl_dac_channel`.
+   - `ad_ip_jesd204_tpl_dac_channel` maps these into `ad_dds` as:
+     - `tone_1_scale`, `tone_1_init_offset`, `tone_1_freq_word`
+     - `tone_2_scale`, `tone_2_init_offset`, `tone_2_freq_word`
+
+**FTW/POW/ASF equivalence in this path**
+- FTW equivalent: `dac_dds_incr_[0|1]` (channel view) / `tone_[1|2]_freq_word` (DDS core view)
+- POW equivalent: `dac_dds_init_[0|1]` / `tone_[1|2]_init_offset`
+- ASF equivalent: `dac_dds_scale_[0|1]` / `tone_[1|2]_scale`
+
+### 9.3 Chosen integration strategy
+
+**Selected approach:** add an **external scheduled-control port bundle** to the
+TPL hierarchy and mux internally.
+
+Rationale for this project:
+- Keeps existing AXI register map and firmware ABI stable.
+- Reuses the current per-channel/tone DDS plumbing and only adds a deterministic
+  override path at the TPL boundary.
+- Minimizes risk of broad regmap surgery in shared ADI library code.
+
+### 9.4 Concrete insertion boundaries for scheduled control
+
+Planned integration points (module/signal level):
+
+- **Hierarchy export point (BD-visible):**
+  - Extend `adi_tpl_jesd204_tx_create` (`library/jesd204/scripts/jesd204.tcl`) to
+    export a scheduled-control bundle from `dac_tpl_core` up to `axi_ad9144_tpl`.
+- **Top-level TPL boundary:**
+  - Add new inputs in `ad_ip_jesd204_tpl_dac.v` (scheduled controls + `valid/ready`
+    or strobe semantics), then feed muxed outputs into existing core inputs:
+    - `dac_dds_scale_0_s`, `dac_dds_init_0_s`, `dac_dds_incr_0_s`
+    - `dac_dds_scale_1_s`, `dac_dds_init_1_s`, `dac_dds_incr_1_s`
+- **Mux point before per-channel slicing:**
+  - Perform source select in `ad_ip_jesd204_tpl_dac.v` (or immediately in
+    `ad_ip_jesd204_tpl_dac_core.v`) so downstream logic remains unchanged.
+- **No change boundary (kept intact):**
+  - `up_dac_channel` register bank semantics and existing AXI writes remain as the
+    unscheduled/base profile source.

--- a/projects/awg/common/awg_bd.tcl
+++ b/projects/awg/common/awg_bd.tcl
@@ -59,6 +59,23 @@ adi_axi_jesd204_tx_create axi_ad9144_jesd $NUM_OF_LANES $NUM_LINKS
 
 # =============================================================================
 # JESD204 transport layer peripheral
+# TPL hierarchy interface contract (created by adi_tpl_jesd204_tx_create):
+#   AXI-exposed control plane (CPU-visible @ 0x44A04000):
+#     - axi_ad9144_tpl/s_axi_aclk
+#     - axi_ad9144_tpl/s_axi_aresetn
+#     - axi_ad9144_tpl/s_axi              (AXI4-Lite slave)
+#   Streaming/data-plane interfaces (external to hierarchy, not register control):
+#     - axi_ad9144_tpl/link_clk
+#     - axi_ad9144_tpl/link               (AXIS toward JESD TX link layer)
+#     - axi_ad9144_tpl/dac_dunf
+#     - axi_ad9144_tpl/dac_enable_<i>, axi_ad9144_tpl/dac_valid_<i>, axi_ad9144_tpl/dac_data_<i>
+#   Internal-only TPL core control pins (exist on axi_ad9144_tpl/dac_tpl_core,
+#   but are not exported by this hierarchy in adi_tpl_jesd204_tx_create):
+#     - dac_sync_in
+#     - dac_sync_manual_req_in
+#     - dac_sync_manual_req_out
+# These internal-only pins are therefore not currently routable at the project BD
+# level unless the TPL hierarchy creation procedure is extended.
 adi_tpl_jesd204_tx_create axi_ad9144_tpl $NUM_OF_LANES \
                                          $NUM_OF_CONVERTERS \
                                          $SAMPLES_PER_FRAME \


### PR DESCRIPTION
### Motivation
- Make the AWG TPL control-plane boundaries explicit so scheduled-control (FTW/POW/ASF-equivalent) integration can be planned without risky changes to the ADI library or firmware ABI.

### Description
- Documented the TPL hierarchy interface contract and which `axi_ad9144_tpl` ports are AXI-exposed vs streaming/data-plane vs internal-only in `projects/awg/common/awg_bd.tcl`.
- Added a `TPL timed-control insertion map` to `projects/awg/SYSTEM_OVERVIEW.md` that names the RTL modules and signals where DDS controls are latched and committed, including `ad_ip_jesd204_tpl_dac` (top), `ad_ip_jesd204_tpl_dac_regmap`, `up_dac_channel`, `up_xfer_cntrl`, `ad_ip_jesd204_tpl_dac_core`, and `ad_ip_jesd204_tpl_dac_channel` and the key signals `up_dac_dds_*` / `dac_dds_scale_*`, `dac_dds_init_*`, `dac_dds_incr_*` / `tone_*` mappings.
- Selected and recorded the integration strategy: add an external scheduled-control port bundle exported by `adi_tpl_jesd204_tx_create` and mux it at the TPL boundary (feed into `dac_dds_*` arrays before per-channel slicing) to preserve the existing AXI regmap and `up_dac_channel` semantics.
- Skills used: none — work performed by repository inspection and small documentation edits.

### Testing
- Ran repository sanity checks and review commands: `git status --short` and `git diff` to verify the two documentation files changed (`projects/awg/common/awg_bd.tcl` and `projects/awg/SYSTEM_OVERVIEW.md`) and reviewed the diffs, which succeeded. 
- No RTL/build tests were run because the change is documentation-only and does not modify HDL sources or firmware interfaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73f09fe1c832bbdc6fca5c9f3fce5)