### PR TITLE
awg: add minimal timed-event AXI-Lite control peripheral

### DIFF
--- a/projects/awg/SYSTEM_OVERVIEW.md
+++ b/projects/awg/SYSTEM_OVERVIEW.md
@@ -242,3 +242,36 @@ Planned integration points (module/signal level):
 - **No change boundary (kept intact):**
   - `up_dac_channel` register bank semantics and existing AXI writes remain as the
     unscheduled/base profile source.
+
+### 9.5 Firmware-facing timed-event control register block (`awg_timed_ctrl`)
+
+A minimal AXI-Lite timed-control peripheral is now inserted in the AWG BD as
+`awg_timed_ctrl_0` at deterministic base address **`0x44AA0000`**.
+
+#### Address map
+
+| Absolute address | Offset | Register | Access | Notes |
+|---|---:|---|---|---|
+| `0x44AA0000` | `0x00` | `CTRL` | RW | Control bits (`bit0` write-1: commit pulse; `bit1`: enable/arm) |
+| `0x44AA0004` | `0x04` | `STATUS` | RO | Status/ack indicators |
+| `0x44AA0008` | `0x08` | `TIME_LO` | RW | Lower 32 bits of target event time |
+| `0x44AA000C` | `0x0C` | `TIME_HI` | RW | Upper 32 bits of target event time |
+| `0x44AA0010` | `0x10` | `LAST_EXEC_LO` | RO | Lower 32 bits of last committed execution time |
+| `0x44AA0014` | `0x14` | `LAST_EXEC_HI` | RO | Upper 32 bits of last committed execution time |
+| `0x44AA0018` | `0x18` | `LAST_APPLY_LO` | RO | Lower 32 bits of local scheduler timestamp at apply |
+| `0x44AA001C` | `0x1C` | `LAST_APPLY_HI` | RO | Upper 32 bits of local scheduler timestamp at apply |
+| `0x44AA0020` | `0x20` | `COMMIT_COUNT` | RO | Number of accepted commit pulses |
+| `0x44AA0024` | `0x24` | `EVENT_COUNT` | RO | Number of event entries written to storage window |
+| `0x44AA0040` | `0x40` | `EVENT_WDATA0` | RW | Packed write-window data word 0 |
+| `0x44AA0044` | `0x44` | `EVENT_WDATA1` | RW | Packed write-window data word 1 |
+| `0x44AA0048` | `0x48` | `EVENT_WDATA2` | RW | Packed write-window data word 2 |
+| `0x44AA004C` | `0x4C` | `EVENT_WDATA3` | RW | Packed write-window data word 3 |
+| `0x44AA0050` | `0x50` | `EVENT_WADDR` | RW | Event RAM write address |
+| `0x44AA0054` | `0x54` | `EVENT_WCTRL` | WO | `bit0` write-1 pushes `{WDATA3..0}` into internal event RAM |
+
+#### Clocking / CDC contract
+
+- **Scheduler execution clock domain:** `util_awg_xcvr/tx_out_clk_0`.
+- **Configuration/control domain:** `sys_cpu_clk` via AXI-Lite.
+- **CDC strategy:** only config-to-scheduler transactions cross domains
+  (commit pulse + event write requests via toggle synchronizers).

--- a/projects/awg/common/awg_bd.tcl
+++ b/projects/awg/common/awg_bd.tcl
@@ -185,6 +185,13 @@ ad_connect tx_sync_0 jesd_sysref_sync/sync_in
 ad_connect jesd_sysref_sync/sysref_pulse axi_ad9144_jesd/sysref
 ad_connect jesd_sysref_sync/sync_out axi_ad9144_jesd/sync
 
+create_bd_cell -type module -reference awg_timed_ctrl awg_timed_ctrl_0
+
+ad_connect sys_cpu_clk awg_timed_ctrl_0/s_axi_aclk
+ad_connect sys_cpu_resetn awg_timed_ctrl_0/s_axi_aresetn
+ad_connect util_awg_xcvr/tx_out_clk_0 awg_timed_ctrl_0/sched_clk
+ad_connect axi_ad9144_jesd_rstgen/peripheral_reset awg_timed_ctrl_0/sched_reset
+
 ad_connect  util_awg_xcvr/tx_out_clk_0 axi_ad9144_tpl/link_clk
 ad_connect  axi_ad9144_jesd/tx_data axi_ad9144_tpl/link
 ad_connect  util_awg_xcvr/tx_out_clk_0 axi_ad9144_upack/clk
@@ -230,6 +237,7 @@ ad_connect axi_dac_fifo/dma_xfer_last axi_ad9144_dma/m_axis_last
 ad_cpu_interconnect 0x44A60000 axi_ad9144_xcvr
 ad_cpu_interconnect 0x44A04000 axi_ad9144_tpl
 ad_cpu_interconnect 0x44A90000 axi_ad9144_jesd
+ad_cpu_interconnect 0x44AA0000 awg_timed_ctrl_0
 ad_cpu_interconnect 0x7c420000 axi_ad9144_dma
 
 

--- a/projects/awg/common/awg_timed_ctrl.v
+++ b/projects/awg/common/awg_timed_ctrl.v
@@ -1,0 +1,239 @@
+module awg_timed_ctrl #(
+  parameter integer EVENT_MEM_ADDR_WIDTH = 8
+) (
+  input  wire                       s_axi_aclk,
+  input  wire                       s_axi_aresetn,
+  input  wire [7:0]                 s_axi_awaddr,
+  input  wire                       s_axi_awvalid,
+  output reg                        s_axi_awready,
+  input  wire [31:0]                s_axi_wdata,
+  input  wire [3:0]                 s_axi_wstrb,
+  input  wire                       s_axi_wvalid,
+  output reg                        s_axi_wready,
+  output reg  [1:0]                 s_axi_bresp,
+  output reg                        s_axi_bvalid,
+  input  wire                       s_axi_bready,
+  input  wire [7:0]                 s_axi_araddr,
+  input  wire                       s_axi_arvalid,
+  output reg                        s_axi_arready,
+  output reg  [31:0]                s_axi_rdata,
+  output reg  [1:0]                 s_axi_rresp,
+  output reg                        s_axi_rvalid,
+  input  wire                       s_axi_rready,
+  input  wire                       sched_clk,
+  input  wire                       sched_reset
+);
+
+  localparam integer EVENT_MEM_DEPTH = (1 << EVENT_MEM_ADDR_WIDTH);
+
+  localparam [7:0] REG_CTRL         = 8'h00;
+  localparam [7:0] REG_STATUS       = 8'h04;
+  localparam [7:0] REG_TIME_LO      = 8'h08;
+  localparam [7:0] REG_TIME_HI      = 8'h0C;
+  localparam [7:0] REG_LAST_EXEC_LO = 8'h10;
+  localparam [7:0] REG_LAST_EXEC_HI = 8'h14;
+  localparam [7:0] REG_LAST_APPLY_LO= 8'h18;
+  localparam [7:0] REG_LAST_APPLY_HI= 8'h1C;
+  localparam [7:0] REG_COMMIT_COUNT = 8'h20;
+  localparam [7:0] REG_EVENT_COUNT  = 8'h24;
+  localparam [7:0] REG_EVENT_WDATA0 = 8'h40;
+  localparam [7:0] REG_EVENT_WDATA1 = 8'h44;
+  localparam [7:0] REG_EVENT_WDATA2 = 8'h48;
+  localparam [7:0] REG_EVENT_WDATA3 = 8'h4C;
+  localparam [7:0] REG_EVENT_WADDR  = 8'h50;
+  localparam [7:0] REG_EVENT_WCTRL  = 8'h54;
+
+  reg [31:0] ctrl_reg;
+  reg [63:0] time_reg;
+  reg [31:0] event_wdata0_reg, event_wdata1_reg, event_wdata2_reg, event_wdata3_reg;
+  reg [EVENT_MEM_ADDR_WIDTH-1:0] event_waddr_reg;
+  reg [EVENT_MEM_ADDR_WIDTH-1:0] event_wr_addr_cfg;
+  reg [127:0] event_wr_data_cfg;
+
+  reg commit_req_tgl, event_wr_req_tgl;
+  reg commit_ack_sync1, commit_ack_sync2, commit_ack_sync2_d;
+  reg event_wr_ack_sync1, event_wr_ack_sync2, event_wr_ack_sync2_d;
+
+  reg [31:0] commit_count_shadow, event_count_shadow;
+  reg [63:0] last_exec_shadow, last_apply_shadow;
+
+  reg [31:0] commit_count_sched, event_count_sched;
+  reg [63:0] sched_time_counter, last_exec_sched, last_apply_sched;
+  reg [127:0] event_mem [0:EVENT_MEM_DEPTH-1];
+
+  reg commit_req_sync1, commit_req_sync2, commit_req_sync2_d;
+  reg event_wr_req_sync1, event_wr_req_sync2, event_wr_req_sync2_d;
+  reg commit_ack_tgl, event_wr_ack_tgl;
+
+  wire write_fire = s_axi_awvalid && s_axi_wvalid && s_axi_awready && s_axi_wready;
+  wire read_fire  = s_axi_arvalid && s_axi_arready;
+
+  integer i;
+
+  always @(posedge s_axi_aclk) begin
+    if (!s_axi_aresetn) begin
+      s_axi_awready <= 1'b1;
+      s_axi_wready <= 1'b1;
+      s_axi_bresp <= 2'b00;
+      s_axi_bvalid <= 1'b0;
+      s_axi_arready <= 1'b1;
+      s_axi_rdata <= 32'h0;
+      s_axi_rresp <= 2'b00;
+      s_axi_rvalid <= 1'b0;
+      ctrl_reg <= 32'h0;
+      time_reg <= 64'h0;
+      event_wdata0_reg <= 32'h0;
+      event_wdata1_reg <= 32'h0;
+      event_wdata2_reg <= 32'h0;
+      event_wdata3_reg <= 32'h0;
+      event_waddr_reg <= 'h0;
+      event_wr_addr_cfg <= 'h0;
+      event_wr_data_cfg <= 128'h0;
+      commit_req_tgl <= 1'b0;
+      event_wr_req_tgl <= 1'b0;
+      commit_ack_sync1 <= 1'b0;
+      commit_ack_sync2 <= 1'b0;
+      commit_ack_sync2_d <= 1'b0;
+      event_wr_ack_sync1 <= 1'b0;
+      event_wr_ack_sync2 <= 1'b0;
+      event_wr_ack_sync2_d <= 1'b0;
+      commit_count_shadow <= 32'h0;
+      event_count_shadow <= 32'h0;
+      last_exec_shadow <= 64'h0;
+      last_apply_shadow <= 64'h0;
+    end else begin
+      if (s_axi_bvalid && s_axi_bready) s_axi_bvalid <= 1'b0;
+      if (s_axi_rvalid && s_axi_rready) s_axi_rvalid <= 1'b0;
+
+      if (write_fire && !s_axi_bvalid) begin
+        s_axi_bvalid <= 1'b1;
+        case (s_axi_awaddr)
+          REG_CTRL: if (s_axi_wstrb[0]) begin
+            ctrl_reg[7:0] <= s_axi_wdata[7:0];
+            if (s_axi_wdata[0]) commit_req_tgl <= ~commit_req_tgl;
+          end
+          REG_TIME_LO: begin
+            if (s_axi_wstrb[0]) time_reg[7:0] <= s_axi_wdata[7:0];
+            if (s_axi_wstrb[1]) time_reg[15:8] <= s_axi_wdata[15:8];
+            if (s_axi_wstrb[2]) time_reg[23:16] <= s_axi_wdata[23:16];
+            if (s_axi_wstrb[3]) time_reg[31:24] <= s_axi_wdata[31:24];
+          end
+          REG_TIME_HI: begin
+            if (s_axi_wstrb[0]) time_reg[39:32] <= s_axi_wdata[7:0];
+            if (s_axi_wstrb[1]) time_reg[47:40] <= s_axi_wdata[15:8];
+            if (s_axi_wstrb[2]) time_reg[55:48] <= s_axi_wdata[23:16];
+            if (s_axi_wstrb[3]) time_reg[63:56] <= s_axi_wdata[31:24];
+          end
+          REG_EVENT_WDATA0: begin
+            if (s_axi_wstrb[0]) event_wdata0_reg[7:0] <= s_axi_wdata[7:0];
+            if (s_axi_wstrb[1]) event_wdata0_reg[15:8] <= s_axi_wdata[15:8];
+            if (s_axi_wstrb[2]) event_wdata0_reg[23:16] <= s_axi_wdata[23:16];
+            if (s_axi_wstrb[3]) event_wdata0_reg[31:24] <= s_axi_wdata[31:24];
+          end
+          REG_EVENT_WDATA1: begin
+            if (s_axi_wstrb[0]) event_wdata1_reg[7:0] <= s_axi_wdata[7:0];
+            if (s_axi_wstrb[1]) event_wdata1_reg[15:8] <= s_axi_wdata[15:8];
+            if (s_axi_wstrb[2]) event_wdata1_reg[23:16] <= s_axi_wdata[23:16];
+            if (s_axi_wstrb[3]) event_wdata1_reg[31:24] <= s_axi_wdata[31:24];
+          end
+          REG_EVENT_WDATA2: begin
+            if (s_axi_wstrb[0]) event_wdata2_reg[7:0] <= s_axi_wdata[7:0];
+            if (s_axi_wstrb[1]) event_wdata2_reg[15:8] <= s_axi_wdata[15:8];
+            if (s_axi_wstrb[2]) event_wdata2_reg[23:16] <= s_axi_wdata[23:16];
+            if (s_axi_wstrb[3]) event_wdata2_reg[31:24] <= s_axi_wdata[31:24];
+          end
+          REG_EVENT_WDATA3: begin
+            if (s_axi_wstrb[0]) event_wdata3_reg[7:0] <= s_axi_wdata[7:0];
+            if (s_axi_wstrb[1]) event_wdata3_reg[15:8] <= s_axi_wdata[15:8];
+            if (s_axi_wstrb[2]) event_wdata3_reg[23:16] <= s_axi_wdata[23:16];
+            if (s_axi_wstrb[3]) event_wdata3_reg[31:24] <= s_axi_wdata[31:24];
+          end
+          REG_EVENT_WADDR: event_waddr_reg <= s_axi_wdata[EVENT_MEM_ADDR_WIDTH-1:0];
+          REG_EVENT_WCTRL: if (s_axi_wstrb[0] && s_axi_wdata[0]) begin
+            event_wr_addr_cfg <= event_waddr_reg;
+            event_wr_data_cfg <= {event_wdata3_reg, event_wdata2_reg, event_wdata1_reg, event_wdata0_reg};
+            event_wr_req_tgl <= ~event_wr_req_tgl;
+          end
+          default: ;
+        endcase
+      end
+
+      if (read_fire && !s_axi_rvalid) begin
+        s_axi_rvalid <= 1'b1;
+        case (s_axi_araddr)
+          REG_CTRL: s_axi_rdata <= ctrl_reg;
+          REG_STATUS: s_axi_rdata <= {30'h0, commit_ack_sync2 ^ commit_ack_sync2_d, ctrl_reg[1]};
+          REG_TIME_LO: s_axi_rdata <= time_reg[31:0];
+          REG_TIME_HI: s_axi_rdata <= time_reg[63:32];
+          REG_LAST_EXEC_LO: s_axi_rdata <= last_exec_shadow[31:0];
+          REG_LAST_EXEC_HI: s_axi_rdata <= last_exec_shadow[63:32];
+          REG_LAST_APPLY_LO: s_axi_rdata <= last_apply_shadow[31:0];
+          REG_LAST_APPLY_HI: s_axi_rdata <= last_apply_shadow[63:32];
+          REG_COMMIT_COUNT: s_axi_rdata <= commit_count_shadow;
+          REG_EVENT_COUNT: s_axi_rdata <= event_count_shadow;
+          REG_EVENT_WDATA0: s_axi_rdata <= event_wdata0_reg;
+          REG_EVENT_WDATA1: s_axi_rdata <= event_wdata1_reg;
+          REG_EVENT_WDATA2: s_axi_rdata <= event_wdata2_reg;
+          REG_EVENT_WDATA3: s_axi_rdata <= event_wdata3_reg;
+          REG_EVENT_WADDR: s_axi_rdata <= {{(32-EVENT_MEM_ADDR_WIDTH){1'b0}}, event_waddr_reg};
+          default: s_axi_rdata <= 32'h0;
+        endcase
+      end
+
+      commit_ack_sync1 <= commit_ack_tgl;
+      commit_ack_sync2 <= commit_ack_sync1;
+      commit_ack_sync2_d <= commit_ack_sync2;
+      if (commit_ack_sync2 ^ commit_ack_sync2_d) begin
+        commit_count_shadow <= commit_count_sched;
+        last_exec_shadow <= last_exec_sched;
+        last_apply_shadow <= last_apply_sched;
+      end
+
+      event_wr_ack_sync1 <= event_wr_ack_tgl;
+      event_wr_ack_sync2 <= event_wr_ack_sync1;
+      event_wr_ack_sync2_d <= event_wr_ack_sync2;
+      if (event_wr_ack_sync2 ^ event_wr_ack_sync2_d) event_count_shadow <= event_count_sched;
+    end
+  end
+
+  always @(posedge sched_clk) begin
+    if (sched_reset) begin
+      commit_req_sync1 <= 1'b0;
+      commit_req_sync2 <= 1'b0;
+      commit_req_sync2_d <= 1'b0;
+      event_wr_req_sync1 <= 1'b0;
+      event_wr_req_sync2 <= 1'b0;
+      event_wr_req_sync2_d <= 1'b0;
+      commit_ack_tgl <= 1'b0;
+      event_wr_ack_tgl <= 1'b0;
+      commit_count_sched <= 32'h0;
+      event_count_sched <= 32'h0;
+      sched_time_counter <= 64'h0;
+      last_exec_sched <= 64'h0;
+      last_apply_sched <= 64'h0;
+      for (i = 0; i < EVENT_MEM_DEPTH; i = i + 1) event_mem[i] <= 128'h0;
+    end else begin
+      sched_time_counter <= sched_time_counter + 1'b1;
+
+      commit_req_sync1 <= commit_req_tgl;
+      commit_req_sync2 <= commit_req_sync1;
+      commit_req_sync2_d <= commit_req_sync2;
+      if (commit_req_sync2 ^ commit_req_sync2_d) begin
+        commit_count_sched <= commit_count_sched + 1'b1;
+        last_exec_sched <= time_reg;
+        last_apply_sched <= sched_time_counter;
+        commit_ack_tgl <= ~commit_ack_tgl;
+      end
+
+      event_wr_req_sync1 <= event_wr_req_tgl;
+      event_wr_req_sync2 <= event_wr_req_sync1;
+      event_wr_req_sync2_d <= event_wr_req_sync2;
+      if (event_wr_req_sync2 ^ event_wr_req_sync2_d) begin
+        event_mem[event_wr_addr_cfg] <= event_wr_data_cfg;
+        event_count_sched <= event_count_sched + 1'b1;
+        event_wr_ack_tgl <= ~event_wr_ack_tgl;
+      end
+    end
+  end
+
+endmodule

--- a/projects/awg/kcu116/system_bd.tcl
+++ b/projects/awg/kcu116/system_bd.tcl
@@ -5,6 +5,7 @@ set dac_fifo_address_width 14
 source $ad_hdl_dir/projects/common/kcu116/kcu116_system_bd.tcl
 source $ad_hdl_dir/projects/common/xilinx/dacfifo_bd.tcl
 add_files -norecurse ../common/jesd_sysref_sync.v
+add_files -norecurse ../common/awg_timed_ctrl.v
 source ../common/awg_bd.tcl
 source $ad_hdl_dir/projects/scripts/adi_pd.tcl
 

--- a/projects/awg/kcu116/system_project.tcl
+++ b/projects/awg/kcu116/system_project.tcl
@@ -46,6 +46,7 @@ adi_project awg_kcu116 0 [list \
 adi_project_files awg_kcu116 [list \
 "../common/awg_spi.v" \
   "../common/jesd_sysref_sync.v" \
+  "../common/awg_timed_ctrl.v" \
   "system_top.v" \
   "system_constr.xdc"\
   "$ad_hdl_dir/library/common/ad_iobuf.v" \


### PR DESCRIPTION
### Motivation

- Provide a minimal firmware-facing register interface for deterministic timed events so software can commit scheduled changes and load event data while the scheduler datapath is developed. 
- Expose a simple event storage/write-window mechanism and keep scheduler execution on the transceiver-derived clock with configuration/control on the CPU AXI clock, enforcing CDC only on control/requests.

### Description

- Add a new AXI-Lite peripheral `awg_timed_ctrl` implemented in `projects/awg/common/awg_timed_ctrl.v` that exposes registers `CTRL`, `STATUS`, `TIME_*`, `LAST_*`, `COMMIT_COUNT`, `EVENT_COUNT` and packed write-window registers `EVENT_WDATA0..3`, `EVENT_WADDR`, `EVENT_WCTRL` feeding an internal event RAM.
- Instantiate the peripheral in the AWG block design via `projects/awg/common/awg_bd.tcl` as `awg_timed_ctrl_0`, connect the scheduler side clock to `util_awg_xcvr/tx_out_clk_0` and provide reset/AXI clock connections, and reserve a deterministic CPU base address `0x44AA0000` via `ad_cpu_interconnect`.
- Add the new RTL to project source lists (`projects/awg/kcu116/system_bd.tcl`, `projects/awg/kcu116/system_project.tcl`) so project generation resolves the module reference, and document the register/address map and CDC/clock contract in `projects/awg/SYSTEM_OVERVIEW.md`.
- Use toggle-based synchronizers for config→scheduler crossing so only control and write-request paths cross domains; the scheduler logic (time counter, event RAM writes, commit handling) runs in the `sched_clk` domain.

### Testing

- Attempted HDL lint with `iverilog -g2012 -t null projects/awg/common/awg_timed_ctrl.v`, but the tool is not installed in this environment so lint could not be performed (failed).
- Attempted lint with `verilator --lint-only projects/awg/common/awg_timed_ctrl.v`, but `verilator` is not available in this environment so lint could not be performed (failed).
- No additional automated unit/simulation tests were run in this environment; RTL integration and timing verification should be performed in the normal build environment with available HDL toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d917f4e450832bae44845b4b08c585)