### PR TITLE
Add deterministic scheduler commit marker output and KCU116 pin mapping

### DIFF
--- a/projects/awg/SYSTEM_BLOCK_DIAGRAM_AND_DATAPATHS.md
+++ b/projects/awg/SYSTEM_BLOCK_DIAGRAM_AND_DATAPATHS.md
@@ -238,6 +238,13 @@ Implemented and exercised in the current default baseline:
 - STPL and TPL PN validation paths.
 - Subclass-1 bring-up with OUT1/OUT6/OUT7/OUT9 clocking and internal SYSREF capture in `axi_jesd204_tx`.
 
+## 11) Scheduler marker probe point (deterministic commit marker)
+
+- **Probe signal**: `marker_commit` top-level output from `projects/awg/kcu116/system_top.v`.
+- **Physical pin**: `AF19` (`LVCMOS18`) in `projects/awg/kcu116/system_constr.xdc`.
+- **Polarity / behavior**: **active-high pulse**, one `sched_clk` cycle wide, asserted when the timed-control scheduler accepts a commit request (`commit_req_sync2 ^ commit_req_sync2_d` event in `awg_timed_ctrl`).
+- **Measurement hookup**: connect oscilloscope/logic-analyzer tip to the routed marker pin and reference to board ground to timestamp commit edges versus SYSREF/SYNC events.
+
 Implemented but not part of the current primary automated benchmark path:
 - DMA waveform path through DMAC and util_dacfifo.
 - Optional AD9144 on-chip NCO control for later placement experiments.

--- a/projects/awg/SYSTEM_OVERVIEW.md
+++ b/projects/awg/SYSTEM_OVERVIEW.md
@@ -52,6 +52,13 @@ comes directly from AD9516 OUT9.
 The AD9144's receive-side XBAR remaps physical lanes {4,5,6,7} → logical {0,1,2,3}
 with polarity inversion on lane 2 to match the FMC-EBZ board routing.
 
+### Scheduler marker output (lab probing)
+
+- **Exact probe point**: `marker_commit` top-level HDL port on `system_top`.
+- **Constraint location**: PACKAGE pin `AF19`, `IOSTANDARD LVCMOS18`.
+- **Signal polarity**: active-high pulse (1 = commit event), generated for one scheduler clock cycle when the scheduler commit handshake is accepted.
+- **Hookup note**: probe `marker_commit` single-ended to ground; use this edge as the deterministic timestamp reference for commit-to-output latency measurements.
+
 ## 3. JESD204B Link
 
 | Parameter | Value |

--- a/projects/awg/common/awg_bd.tcl
+++ b/projects/awg/common/awg_bd.tcl
@@ -192,6 +192,9 @@ ad_connect sys_cpu_resetn awg_timed_ctrl_0/s_axi_aresetn
 ad_connect util_awg_xcvr/tx_out_clk_0 awg_timed_ctrl_0/sched_clk
 ad_connect axi_ad9144_jesd_rstgen/peripheral_reset awg_timed_ctrl_0/sched_reset
 
+create_bd_port -dir O marker_commit
+ad_connect marker_commit awg_timed_ctrl_0/marker_commit
+
 ad_connect  util_awg_xcvr/tx_out_clk_0 axi_ad9144_tpl/link_clk
 ad_connect  axi_ad9144_jesd/tx_data axi_ad9144_tpl/link
 ad_connect  util_awg_xcvr/tx_out_clk_0 axi_ad9144_upack/clk

--- a/projects/awg/common/awg_timed_ctrl.v
+++ b/projects/awg/common/awg_timed_ctrl.v
@@ -21,7 +21,10 @@ module awg_timed_ctrl #(
   output reg                        s_axi_rvalid,
   input  wire                       s_axi_rready,
   input  wire                       sched_clk,
-  input  wire                       sched_reset
+  input  wire                       sched_reset,
+  output reg                        marker_commit,
+  output reg                        marker_start,
+  output reg                        marker_done
 );
 
   localparam integer EVENT_MEM_DEPTH = (1 << EVENT_MEM_ADDR_WIDTH);
@@ -211,9 +214,15 @@ module awg_timed_ctrl #(
       sched_time_counter <= 64'h0;
       last_exec_sched <= 64'h0;
       last_apply_sched <= 64'h0;
+      marker_commit <= 1'b0;
+      marker_start <= 1'b0;
+      marker_done <= 1'b0;
       for (i = 0; i < EVENT_MEM_DEPTH; i = i + 1) event_mem[i] <= 128'h0;
     end else begin
       sched_time_counter <= sched_time_counter + 1'b1;
+      marker_commit <= 1'b0;
+      marker_start <= 1'b0;
+      marker_done <= 1'b0;
 
       commit_req_sync1 <= commit_req_tgl;
       commit_req_sync2 <= commit_req_sync1;
@@ -223,6 +232,9 @@ module awg_timed_ctrl #(
         last_exec_sched <= time_reg;
         last_apply_sched <= sched_time_counter;
         commit_ack_tgl <= ~commit_ack_tgl;
+        marker_commit <= 1'b1;
+        marker_start <= 1'b1;
+        marker_done <= 1'b1;
       end
 
       event_wr_req_sync1 <= event_wr_req_tgl;

--- a/projects/awg/kcu116/system_constr.xdc
+++ b/projects/awg/kcu116/system_constr.xdc
@@ -26,6 +26,9 @@ set_property -dict {PACKAGE_PIN AB17 IOSTANDARD LVCMOS18} [get_ports spi_clk]
 set_property -dict {PACKAGE_PIN AD16 IOSTANDARD LVCMOS18} [get_ports {dac_ctrl[0]}]
 set_property -dict {PACKAGE_PIN AE16 IOSTANDARD LVCMOS18} [get_ports {dac_ctrl[1]}]
 
+# Scheduler commit marker: probe this pin (single-ended) against GND to capture commit pulses.
+set_property -dict {PACKAGE_PIN AF19 IOSTANDARD LVCMOS18} [get_ports marker_commit]
+
 
 
 

--- a/projects/awg/kcu116/system_top.v
+++ b/projects/awg/kcu116/system_top.v
@@ -55,7 +55,8 @@ module system_top #(
   output                  spi_en,        // SPI enable (direction control for spi_sdio)
 
   // DAC Control Signals
-  inout       [1:0]       dac_ctrl       // DAC control signals (e.g., FMC_HPC0_LA07_P)
+  inout       [1:0]       dac_ctrl,      // DAC control signals (e.g., FMC_HPC0_LA07_P)
+  output                  marker_commit  // Scheduler commit marker pulse output
 );
 
   // Internal Signals
@@ -206,7 +207,10 @@ module system_top #(
     .uart_sout       (uart_sout),
 
     // DAC FIFO Bypass
-    .dac_fifo_bypass (dac_fifo_bypass)
+    .dac_fifo_bypass (dac_fifo_bypass),
+
+    // Scheduler marker output
+    .marker_commit   (marker_commit)
   );
 
   // Assign local sysref signal based on device code


### PR DESCRIPTION
### Motivation

- Provide a deterministic, externally-measurable marker that timestamps when the timed-control scheduler accepts a commit so lab measurements (latency/timing) can be correlated to SYSREF/SYNC edges.

### Description

- Added scheduler marker outputs `marker_commit`, `marker_start`, and `marker_done` to `projects/awg/common/awg_timed_ctrl.v` and drive them as one-cycle active-high pulses in the `sched_clk` domain when a commit is accepted (`commit_req_sync2 ^ commit_req_sync2_d`).
- Exported `marker_commit` from the AWG block design by adding a BD output port in `projects/awg/common/awg_bd.tcl` and connected it to the `awg_timed_ctrl` instance.
- Routed `marker_commit` through the system wrapper and exposed it as a dedicated top-level output in `projects/awg/kcu116/system_top.v`.
- Added a KCU116 XDC assignment for the probe pin in `projects/awg/kcu116/system_constr.xdc` (`PACKAGE_PIN AF19`, `IOSTANDARD LVCMOS18`) with a brief measurement hookup comment, and documented the exact probe point and polarity in `projects/awg/SYSTEM_BLOCK_DIAGRAM_AND_DATAPATHS.md` and `projects/awg/SYSTEM_OVERVIEW.md`.

### Testing

- Verified presence and routing of marker signals by searching for `marker_commit|marker_start|marker_done` and inspecting the modified files with `rg` and file dumps (`sed`/`nl`); the expected definitions, connections, and documentation updates are present.
- Confirmed the top-level port and XDC assignment are present in `projects/awg/kcu116/system_top.v` and `projects/awg/kcu116/system_constr.xdc` respectively via file inspection; no synthesis or timing runs were performed.
- No regressions in unrelated files were observed by reviewing the changed file set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3365554c832b908dd1171f44c48f)